### PR TITLE
Fix multiple go buildpack use collision

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,6 @@ source "${buildpack}/lib/common.sh"
 source "${buildpack}/lib/common_tools.sh"
 
 BPLOG_PREFIX="buildpack.go"
-STDLIB_DIR="${TMPDIR:-"/tmp"}/go-buildpack-stdlib"
 source "${STDLIB_DIR}/stdlib.sh.v8"
 
 snapshotBinBefore

--- a/lib/common_tools.sh
+++ b/lib/common_tools.sh
@@ -4,5 +4,9 @@
 ensureInPath "jq-linux64" "${cache}/.jq/bin"
 
 # Ensure we have a copy of the stdlib
-STDLIB_DIR="${TMPDIR:-"/tmp"}/go-buildpack-stdlib"
+if [ -z "${TMPDIR}" ]; then
+  STDLIB_DIR=$(mktemp -d -t stdlib.XXXXX)
+else
+  STDLIB_DIR="${TMPDIR}/go-buildpack-stdlib"
+fi
 ensureFile "stdlib.sh.v8" "${STDLIB_DIR}" "chmod a+x"


### PR DESCRIPTION
### Context

If the go buildpack is used by multiple users in the same environment, users other than the first user are unable to succesfully run `compile`. Running compile results in an exit code of "1", with no output other than this, which only occurs on the first run:

```
-----> Fetching jq... done
```

After the first run, no output appears (because jq is cached), and the exit code is still "1"

This occurs because a recent change to the buildpack replaced the old `mktemp` behaviour with a predefined path to a directory to use for temporary storage [here](https://github.com/heroku/heroku-buildpack-go/blame/master/lib/common_tools.sh#L7).

### Solution

Go back to using `mktemp` to create a temporary directory

Presumably there's a reason to support the `TMPDIR` variable (docker layer caching maybe? I don't know.), so this pull request adds logic to preserve the existing behaviour that uses `$TMPDIR/heroku-buildpack-go` if that variable is set, but otherwise `mktemp -d` is used.